### PR TITLE
Update data-from-other-node.md

### DIFF
--- a/docs/bitcoin/data-from-other-node.md
+++ b/docs/bitcoin/data-from-other-node.md
@@ -41,6 +41,10 @@ sudo scp -r admin@othernode.local:/mnt/hdd/mynode/bitcoin/blocks /mnt/hdd/mynode
 sudo scp -r admin@othernode.local:/mnt/hdd/mynode/bitcoin/chainstate /mnt/hdd/mynode/bitcoin/
 sudo scp -r admin@othernode.local:/mnt/hdd/mynode/bitcoin/indexes /mnt/hdd/mynode/bitcoin/
 sudo chown -R bitcoin:bitcoin /mnt/hdd/mynode/bitcoin/
+
+# Optionally, if the blockchain data you are copying was previously indexed by Electrs and Electrs will be used on the destination node, copy the existing index to save time and avoid reindexing errors
+sudo scp -r admin@othernode.local:/mnt/hdd/mynode/electrs/bitcoin /mnt/hdd/mynode/electrs/
+
 sudo reboot
 ```
 


### PR DESCRIPTION
Added the option to copy over Electrs index. This solves the problem of reindexing errors using the builtin Electrs server which have been experienced when using blockchain data from another device. This code will be different if Electrs was not the previous indexer or the desired indexer in the destination node.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Checklist

* [ ] tested locally using Vuepress
* [ ] mentioned related issue

